### PR TITLE
Expo 331 expo tickets integracion mercado pago

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
-        "expo-backend-types": "^0.40.0-EXPO-330-ExpoBackend-MercadoPago.8",
+        "expo-backend-types": "^0.44.0-EXPO-330-ExpoBackend-MercadoPago.6",
         "lucide-react": "^0.477.0",
         "next": "15.2.1",
         "nuqs": "^2.4.1",
@@ -3609,10 +3609,11 @@
       }
     },
     "node_modules/expo-backend-types": {
-      "version": "0.40.0-EXPO-330-ExpoBackend-MercadoPago.8",
-      "resolved": "https://registry.npmjs.org/expo-backend-types/-/expo-backend-types-0.40.0-EXPO-330-ExpoBackend-MercadoPago.8.tgz",
-      "integrity": "sha512-+s5jSo6Rr77iXtRH29hKrpt9RFn7cjhBkCgfPcN6LlpV4DMmnXDXZK2WRDETD7KQHKpYbutjaLFJG268XuKxCQ==",
+      "version": "0.44.0-EXPO-330-ExpoBackend-MercadoPago.6",
+      "resolved": "https://registry.npmjs.org/expo-backend-types/-/expo-backend-types-0.44.0-EXPO-330-ExpoBackend-MercadoPago.6.tgz",
+      "integrity": "sha512-t8M9X67V+ZtqziH4TzawKZcp0SJGyEM6yxNzR1kP7BhtXWI8n1neDYGYDRM1mLP14+o6KKa7wajyej+RHjFzew==",
       "hasInstallScript": true,
+      "license": "UNLICENSED",
       "dependencies": {
         "@anatine/zod-nestjs": "^2.0.10",
         "@anatine/zod-openapi": "^2.2.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
-        "expo-backend-types": "^0.37.0-EXPO-325-ExpoBackend-Emision-de-multiples-tickets.3",
+        "expo-backend-types": "^0.40.0-EXPO-330-ExpoBackend-MercadoPago.5",
         "lucide-react": "^0.477.0",
         "next": "15.2.1",
         "nuqs": "^2.4.1",
@@ -3609,15 +3609,16 @@
       }
     },
     "node_modules/expo-backend-types": {
-      "version": "0.37.0-EXPO-325-ExpoBackend-Emision-de-multiples-tickets.3",
-      "resolved": "https://registry.npmjs.org/expo-backend-types/-/expo-backend-types-0.37.0-EXPO-325-ExpoBackend-Emision-de-multiples-tickets.3.tgz",
-      "integrity": "sha512-nf38pzCyJsgYjDYB2s3TRVuzzDq1HFuTzHbuc+l8/OAedHhRXbY7FjsU02ZEpII/IwOtSPPWtpko/U85+SBJhQ==",
+      "version": "0.40.0-EXPO-330-ExpoBackend-MercadoPago.5",
+      "resolved": "https://registry.npmjs.org/expo-backend-types/-/expo-backend-types-0.40.0-EXPO-330-ExpoBackend-MercadoPago.5.tgz",
+      "integrity": "sha512-BjSK51wVSw7z3q9nmxgv6VPoFpm62eK+nLaimUeUxt7/22nStFYlH/CZe/hbsUFQ4HgaaZHk+38JqYPSexiQkg==",
       "hasInstallScript": true,
       "dependencies": {
-        "@anatine/zod-nestjs": "^2.0.9",
+        "@anatine/zod-nestjs": "^2.0.10",
         "@anatine/zod-openapi": "^2.2.6",
         "i18n-js": "^4.4.3",
         "libphonenumber-js": "^1.12.6",
+        "mercadopago": "^2.4.0",
         "patch-package": "^8.0.0",
         "zod": "^3.23.8"
       }
@@ -5144,6 +5145,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mercadopago": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/mercadopago/-/mercadopago-2.4.0.tgz",
+      "integrity": "sha512-t5eB1mk+wEoO6g70Do4I8NeEU7nirpMVEyoZpv28UHvRUoHCQH1f9esZ1J/e2qN74IEejrhbnweUV3LomUsW6A==",
+      "dependencies": {
+        "node-fetch": "^2.7.0",
+        "uuid": "^9.0.0"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -5312,7 +5322,6 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -6768,8 +6777,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.0.1",
@@ -7015,6 +7023,18 @@
         }
       }
     },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/validator": {
       "version": "13.12.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
@@ -7029,15 +7049,13 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
-        "expo-backend-types": "^0.40.0-EXPO-330-ExpoBackend-MercadoPago.5",
+        "expo-backend-types": "^0.40.0-EXPO-330-ExpoBackend-MercadoPago.8",
         "lucide-react": "^0.477.0",
         "next": "15.2.1",
         "nuqs": "^2.4.1",
@@ -3609,9 +3609,9 @@
       }
     },
     "node_modules/expo-backend-types": {
-      "version": "0.40.0-EXPO-330-ExpoBackend-MercadoPago.5",
-      "resolved": "https://registry.npmjs.org/expo-backend-types/-/expo-backend-types-0.40.0-EXPO-330-ExpoBackend-MercadoPago.5.tgz",
-      "integrity": "sha512-BjSK51wVSw7z3q9nmxgv6VPoFpm62eK+nLaimUeUxt7/22nStFYlH/CZe/hbsUFQ4HgaaZHk+38JqYPSexiQkg==",
+      "version": "0.40.0-EXPO-330-ExpoBackend-MercadoPago.8",
+      "resolved": "https://registry.npmjs.org/expo-backend-types/-/expo-backend-types-0.40.0-EXPO-330-ExpoBackend-MercadoPago.8.tgz",
+      "integrity": "sha512-+s5jSo6Rr77iXtRH29hKrpt9RFn7cjhBkCgfPcN6LlpV4DMmnXDXZK2WRDETD7KQHKpYbutjaLFJG268XuKxCQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@anatine/zod-nestjs": "^2.0.10",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
-    "expo-backend-types": "^0.37.0-EXPO-325-ExpoBackend-Emision-de-multiples-tickets.3",
+    "expo-backend-types": "^0.40.0-EXPO-330-ExpoBackend-MercadoPago.5",
     "lucide-react": "^0.477.0",
     "next": "15.2.1",
     "nuqs": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
-    "expo-backend-types": "^0.40.0-EXPO-330-ExpoBackend-MercadoPago.8",
+    "expo-backend-types": "^0.44.0-EXPO-330-ExpoBackend-MercadoPago.6",
     "lucide-react": "^0.477.0",
     "next": "15.2.1",
     "nuqs": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
-    "expo-backend-types": "^0.40.0-EXPO-330-ExpoBackend-MercadoPago.5",
+    "expo-backend-types": "^0.40.0-EXPO-330-ExpoBackend-MercadoPago.8",
     "lucide-react": "^0.477.0",
     "next": "15.2.1",
     "nuqs": "^2.4.1",

--- a/src/app/payment/[slug]/page.tsx
+++ b/src/app/payment/[slug]/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import BuyTicketsModal from '@/components/Event/BuyTicketsModal';
+import ErrorModal from '@/components/Event/ErrorModal';
 import { trpc } from '@/server/trpc/client';
 import { useRouter } from 'next/navigation';
 import { use } from 'react';
@@ -17,17 +18,25 @@ export default function PaymentPage({ params }: PaymentPageProps) {
   const router = useRouter();
   return (
     <div>
-      {isLoading && (
+      {isLoading ? (
         <div className='flex justify-center items-center h-screen'>
           Loading...
         </div>
-      )}
-      {ticketGroup?.pdfs && (
-        <BuyTicketsModal
-          pdfs={ticketGroup?.pdfs}
+      ) : ticketGroup?.pdfs ? (
+        ticketGroup?.pdfs && (
+          <BuyTicketsModal
+            pdfs={ticketGroup?.pdfs}
+            isOpen={true}
+            key={slug}
+            onClose={() => router.push(`${process.env.NEXT_PUBLIC_APP_URL}`)}
+          />
+        )
+      ) : (
+        <ErrorModal
           isOpen={true}
-          key={slug}
           onClose={() => router.push(`${process.env.NEXT_PUBLIC_APP_URL}`)}
+          errorTitle='Error'
+          errorMessage='Ha ocurrido un error al procesar el pago'
         />
       )}
     </div>

--- a/src/app/payment/[slug]/page.tsx
+++ b/src/app/payment/[slug]/page.tsx
@@ -1,0 +1,35 @@
+'use client';
+import BuyTicketsModal from '@/components/Event/BuyTicketsModal';
+import { trpc } from '@/server/trpc/client';
+import { useRouter } from 'next/navigation';
+import { use } from 'react';
+
+interface PaymentPageProps {
+  params: Promise<{
+    slug: string;
+  }>;
+}
+
+export default function PaymentPage({ params }: PaymentPageProps) {
+  const { slug } = use(params);
+  const { data: ticketGroup, isLoading } =
+    trpc.ticketGroup.getPdf.useQuery(slug);
+  const router = useRouter();
+  return (
+    <div>
+      {isLoading && (
+        <div className='flex justify-center items-center h-screen'>
+          Loading...
+        </div>
+      )}
+      {ticketGroup?.pdfs && (
+        <BuyTicketsModal
+          pdfs={ticketGroup?.pdfs}
+          isOpen={true}
+          key={slug}
+          onClose={() => router.push(`${process.env.NEXT_PUBLIC_APP_URL}`)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/payment/error/page.tsx
+++ b/src/app/payment/error/page.tsx
@@ -1,0 +1,17 @@
+'use client';
+import ErrorModal from '@/components/Event/ErrorModal';
+import { useRouter } from 'next/navigation';
+
+function ErrorPage() {
+  const router = useRouter();
+  return (
+    <ErrorModal
+      isOpen={true}
+      onClose={() => router.push(`${process.env.NEXT_PUBLIC_APP_URL}`)}
+      errorTitle='Error'
+      errorMessage='Ha ocurrido un error al procesar el pago'
+    />
+  );
+}
+
+export default ErrorPage;

--- a/src/components/Event/BuyTicketsModal.tsx
+++ b/src/components/Event/BuyTicketsModal.tsx
@@ -8,7 +8,7 @@ import { type RouterOutputs } from '@/server/routers/app';
 interface BuyTicketsModalProps {
   isOpen: boolean;
   onClose: () => void;
-  pdfs?: RouterOutputs['tickets']['createMany']['pdfs'];
+  pdfs?: RouterOutputs['ticketGroup']['getPdf']['pdfs'];
 }
 
 function BuyTicketsModal({ isOpen, onClose, pdfs }: BuyTicketsModalProps) {

--- a/src/components/Event/TicketPurchase.tsx
+++ b/src/components/Event/TicketPurchase.tsx
@@ -111,11 +111,7 @@ function TicketPurchase({
         <Button
           className='bg-MiExpo_purple cursor-pointer col-span-1 hover:bg-MiExpo_purple/90 text-MiExpo_white font-medium text-[12px] sm:text-[16px] leading-[100%] px-8 py-2 rounded-[10px]'
           onClick={handlePurchase}
-          disabled={
-            quantity === '0' ||
-            Boolean(eventTicket?.price && eventTicket.price > 0) ||
-            ticketsAvailable < parseInt(quantity)
-          }
+          disabled={quantity === '0' || ticketsAvailable < parseInt(quantity)}
         >
           COMPRAR
         </Button>

--- a/src/components/Event/TicketPurchase.tsx
+++ b/src/components/Event/TicketPurchase.tsx
@@ -56,8 +56,8 @@ function TicketPurchase({
 
   const handleCloseModal = async (bought: boolean) => {
     setIsModalOpen(false);
-    if (!bought) {
-      await deleteTicketGroup.mutateAsync(ticketGroupId || '').then(() => {
+    if (!bought && ticketGroupId) {
+      await deleteTicketGroup.mutateAsync(ticketGroupId).then(() => {
         setTicketGroupId(null);
       });
     }

--- a/src/components/Event/TicketPurchase.tsx
+++ b/src/components/Event/TicketPurchase.tsx
@@ -46,10 +46,6 @@ function TicketPurchase({
       .mutateAsync({
         eventId,
         amountTickets: parseInt(quantity),
-        status:
-          eventTicket.price === null || eventTicket.price === 0
-            ? 'FREE'
-            : 'BOOKED',
       })
       .then((ticketGroupData) => {
         setTicketGroupId(ticketGroupData.id);
@@ -133,7 +129,7 @@ function TicketPurchase({
         isOpen={isModalOpen}
         onClose={handleCloseModal}
         quantity={quantity}
-        price={eventTicket.price || 0}
+        price={eventTicket.price}
         eventId={eventId}
         ticketType={eventTicket.type}
         ticketGroupId={ticketGroupId || ''}

--- a/src/components/Event/TicketPurchaseModal.tsx
+++ b/src/components/Event/TicketPurchaseModal.tsx
@@ -1,5 +1,10 @@
 'use client';
-import { useState, useEffect, type HTMLInputTypeAttribute } from 'react';
+import {
+  useState,
+  useEffect,
+  type HTMLInputTypeAttribute,
+  useCallback,
+} from 'react';
 import {
   Dialog,
   DialogContent,
@@ -107,13 +112,21 @@ function TicketPurchaseModal({
       enabled: price === null && !!ticketGroupIdCreated,
     });
 
+  const handleClose = useCallback(
+    (bought: boolean) => {
+      setErrorMessage('');
+      onClose(bought);
+    },
+    [onClose],
+  );
+
   useEffect(() => {
     if (pdfs?.pdfs) {
       setPdfData(pdfs.pdfs);
       setShowSuccessModal(true);
       handleClose(true);
     }
-  }, [pdfs]);
+  }, [handleClose, pdfs]);
 
   const ticketsCount = parseInt(quantity, 10);
 
@@ -123,12 +136,7 @@ function TicketPurchaseModal({
 
   useEffect(() => {
     setFormData(defaultState(ticketsCount));
-  }, [ticketsCount, isOpen]); // }, [isOpen, ticketsCount]);
-
-  function handleClose(bought: boolean) {
-    setErrorMessage('');
-    onClose(bought);
-  }
+  }, [ticketsCount, isOpen]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setFormData({

--- a/src/components/Events/EventCardContainer.tsx
+++ b/src/components/Events/EventCardContainer.tsx
@@ -13,7 +13,7 @@ interface EventCardContainerProps {
 
 function EventCardContainer({ event }: EventCardContainerProps) {
   const { day, month, year, time, dayOfWeek } = formatEventDate(
-    event.startingDate,
+    event.endingDate,
   );
 
   const eventTicket = event.eventTickets.filter(

--- a/src/components/Events/GridEvents.tsx
+++ b/src/components/Events/GridEvents.tsx
@@ -20,7 +20,7 @@ function GridEvents() {
   if (isLoading) {
     return (
       <div className='max-w-7xl mx-auto py-8 px-4'>
-        <h1 className='text-2xl font-bold'>Cargando eventos...</h1>
+        <h1 className='text-2xl font-bold select-none'>Cargando eventos...</h1>
       </div>
     );
   }

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -33,7 +33,7 @@ function SelectTrigger({
     <SelectPrimitive.Trigger
       data-slot='select-trigger'
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex h-9 w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex h-9 w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 select-none",
         className,
       )}
       {...props}

--- a/src/hooks/useEventTickets.ts
+++ b/src/hooks/useEventTickets.ts
@@ -14,6 +14,10 @@ export function useEventTickets(
     trpc.ticketGroup.getTicketsByEvent.useQuery(eventId);
 
   useEffect(() => {
+    if (eventTicket === undefined || eventTicket === null || !eventTicket) {
+      setEventDisabled(true);
+      return;
+    }
     const maxTickets = eventTicket.amount;
 
     if (maxTickets === undefined || maxTickets === null) {

--- a/src/hooks/useFilteredEvents.ts
+++ b/src/hooks/useFilteredEvents.ts
@@ -27,7 +27,8 @@ export function useFilteredEvents(
     province: (event: Event) =>
       province ? event.location.includes(province) : true, // TODO: Fix this when we have provinces and googleMaps
     city: (event: Event) => (city ? event.location.includes(city) : true), // TODO: Fix this when we have provinces and googleMaps
-    date: (event: Event) => (date ? filterByDate(event.date, date) : true),
+    date: (event: Event) =>
+      date ? filterByDate(event.endingDate, date) : true,
   };
 
   return eventsData.events.filter((event) =>

--- a/src/server/routers/app.ts
+++ b/src/server/routers/app.ts
@@ -3,11 +3,12 @@ import { filterEventsRouter } from '@/server/routers/filterEvents';
 import { type inferRouterOutputs } from '@trpc/server';
 import { ticketsRouter } from '@/server/routers/tickets';
 import { ticketGroupRouter } from '@/server/routers/ticket-group';
-
+import { mercadopagoRouter } from '@/server/routers/mercadopago';
 export const appRouter = router({
   filterEvents: filterEventsRouter,
   tickets: ticketsRouter,
   ticketGroup: ticketGroupRouter,
+  mercadopago: mercadopagoRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/src/server/routers/mercadopago.ts
+++ b/src/server/routers/mercadopago.ts
@@ -1,0 +1,19 @@
+import { handleError, router, ticketsProcedure } from '@/server/trpc';
+import { createPreferenceSchema } from 'expo-backend-types';
+
+export const mercadopagoRouter = router({
+  createPreference: ticketsProcedure
+    .input(createPreferenceSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { data, error } = await ctx.fetch.POST(
+        '/mercadopago/create-preference',
+        {
+          body: input,
+        },
+      );
+      if (error) {
+        throw handleError(error);
+      }
+      return data;
+    }),
+});

--- a/src/server/routers/ticket-group.ts
+++ b/src/server/routers/ticket-group.ts
@@ -19,7 +19,6 @@ export const ticketGroupRouter = router({
       }
       return data;
     }),
-
   getTicketsByEvent: ticketsProcedure
     .input(z.string())
     .query(async ({ ctx, input }) => {
@@ -38,7 +37,30 @@ export const ticketGroupRouter = router({
       }
       return data.tickets;
     }),
-
+  findById: ticketsProcedure.input(z.string()).query(async ({ ctx, input }) => {
+    const { data, error } = await ctx.fetch.GET(
+      '/ticket-group/find-group/{id}',
+      {
+        params: { path: { id: input } },
+      },
+    );
+    if (error) {
+      throw handleError(error);
+    }
+    return data;
+  }),
+  getPdf: ticketsProcedure.input(z.string()).query(async ({ ctx, input }) => {
+    const { data, error } = await ctx.fetch.GET(
+      '/ticket/get-pdfs-by-ticket-group/{ticketGroupId}',
+      {
+        params: { path: { ticketGroupId: input } },
+      },
+    );
+    if (error) {
+      throw handleError(error);
+    }
+    return data;
+  }),
   update: ticketsProcedure
     .input(updateTicketGroupSchema.merge(z.object({ id: z.string() })))
     .mutation(async ({ ctx, input }) => {

--- a/src/server/routers/tickets.ts
+++ b/src/server/routers/tickets.ts
@@ -8,7 +8,10 @@ export const ticketsRouter = router({
     .mutation(async ({ ctx, input }) => {
       const { data, error } = await ctx.fetch.POST('/ticket/create-many', {
         body: {
-          tickets: input,
+          tickets: input.map((ticket) => ({
+            ...ticket,
+            ticketGroupId: ticket.ticketGroupId ?? null,
+          })),
         },
       });
       if (error) {


### PR DESCRIPTION
En este PR se implementa en ET todo lo relacionado a Mercado Pago:
-  Al enviar el formulario con los datos de los tickets, si el precio de tales es mayor a 0, redirige a la preferencia de Mercado Pago para realizar el pago
- Al momento de realizar el pago, si este fue `success` redirige a una página de ET donde se podrá descargar los PDF de los Tickets abonados. Si el pago falló redirigirá a una página indicandole al comprador que hubo un error al realizar el pago.

Además se modifica en el Front el workflow de los pdf de los tickets. Mientras antes los recibía siempre que se creaban los tickets, ahora solo pide los pdfs de los Tickets creados si las entradas eran gratuitas. 